### PR TITLE
Use relative default data directories for offline and online stages

### DIFF
--- a/Galerkin_offline.py
+++ b/Galerkin_offline.py
@@ -11,7 +11,7 @@ NUM_CASES = 8     # 스냅샷(케이스) 개수
 NX, NY = 101, 101  # 격자 크기
 N_NODES = NX * NY
 K = 8    # 사용할 모드의 개수 (최대 NUM_CASES)
-DATA_DIRECTORY = r'C:\Users\spearlab05\Desktop\Galerkin ROM\offlineDATA' # 데이터 파일 경로 지정
+DEFAULT_DATA_DIRECTORY = os.path.join(os.path.dirname(__file__), 'offlineDATA')
 
 # --- 유틸리티 함수 ---
 
@@ -173,22 +173,23 @@ def visualize_interior_snapshot(Q_int_col, nx, ny, case_index, data_directory):
 
 # --- OFFLINE 계산 시작 ---
 
-def run_offline_stage():
+def run_offline_stage(data_directory=None):
     """OFFLINE 단계 전체를 실행합니다."""
     print("--- OFFLINE STAGE START ---")
     start_time = time.time()
 
     # 1. 모든 스냅샷 행렬 Q 구성
-    print(f"1. Loading snapshots from '{DATA_DIRECTORY}' and building Q matrix...")
-    
-    if not os.path.isdir(DATA_DIRECTORY):
-        raise FileNotFoundError(f"지정된 디렉토리를 찾을 수 없습니다: '{DATA_DIRECTORY}'")
+    data_directory = data_directory or DEFAULT_DATA_DIRECTORY
+    print(f"1. Loading snapshots from '{data_directory}' and building Q matrix...")
 
-    file_pattern = os.path.join(DATA_DIRECTORY, 'case*_sorted.csv')
+    if not os.path.isdir(data_directory):
+        raise FileNotFoundError(f"지정된 디렉토리를 찾을 수 없습니다: '{data_directory}'")
+
+    file_pattern = os.path.join(data_directory, 'case*_sorted.csv')
     filepaths = glob.glob(file_pattern)
-    
+
     if len(filepaths) == 0:
-        raise FileNotFoundError(f"디렉토리 '{DATA_DIRECTORY}'에서 'case*_sorted.csv' 패턴의 파일을 찾을 수 없습니다.")
+        raise FileNotFoundError(f"디렉토리 '{data_directory}'에서 'case*_sorted.csv' 패턴의 파일을 찾을 수 없습니다.")
 
     # --- 수정된 부분: 숫자 크기 순으로 파일 정렬 ---
     def get_case_number(path):
@@ -220,7 +221,7 @@ def run_offline_stage():
     # --- ✨1단계 디버깅: 전체 스냅샷 확인✨ ---
     print("1a. [Debug] Visualizing the first FULL snapshot...")
     case_to_visualize = 0 
-    visualize_full_snapshot(Q[:, case_to_visualize], NX, NY, case_to_visualize, DATA_DIRECTORY)
+    visualize_full_snapshot(Q[:, case_to_visualize], NX, NY, case_to_visualize, data_directory)
     # -----------------------------------------
 
 
@@ -240,7 +241,7 @@ def run_offline_stage():
     print("2a. [Debug] Visualizing the first interior snapshot...")
     # 첫 번째 스냅샷(case 1)의 내부 유동장을 이미지로 저장
     case_to_visualize = 0 
-    visualize_interior_snapshot(Q_interior[:, case_to_visualize], NX, NY, case_to_visualize, DATA_DIRECTORY)
+    visualize_interior_snapshot(Q_interior[:, case_to_visualize], NX, NY, case_to_visualize, data_directory)
     # ---------------------------------
 
 
@@ -363,5 +364,6 @@ def run_offline_stage():
 
 
 if __name__ == '__main__':
-    run_offline_stage()
+    default_data_dir = os.environ.get('OFFLINE_DATA_DIRECTORY', DEFAULT_DATA_DIRECTORY)
+    run_offline_stage(default_data_dir)
 

--- a/Galerkin_online.py
+++ b/Galerkin_online.py
@@ -14,10 +14,7 @@ L0  = 0.01    # m
 OFFLINE_WAS_NONDIM = True
 
 
-# --- ✨ 1. 저장 경로를 지정하는 변수 추가 ---
-# 저장할 디렉터리 경로를 정의합니다.
-# raw string (r"...")을 사용하여 Windows 경로의 백슬래시 문제를 방지합니다.
-OUTPUT_DIRECTORY = r'C:\Users\spearlab05\Desktop\Galerkin ROM\FinalResult'
+DEFAULT_OUTPUT_DIRECTORY = os.path.join(os.path.dirname(__file__), 'FinalResult')
 
 def load_offline_data(filepath='rom_offline_data.npz'):
     """저장된 오프라인 데이터를 로드합니다."""
@@ -148,12 +145,13 @@ def plot_solution_interpolated(coords, p, u, v, Re, output_dir):
     plt.close()
     print("Plotting complete.")
 
-def run_online_stage(re_input):
+def run_online_stage(re_input, output_dir=None):
     """ONLINE 단계 전체를 실행합니다."""
     try:
+        output_dir = output_dir or DEFAULT_OUTPUT_DIRECTORY
         # --- ✨ 4. 저장할 디렉터리가 없으면 자동으로 생성 ---
-        os.makedirs(OUTPUT_DIRECTORY, exist_ok=True)
-        print(f"Output files will be saved to: '{OUTPUT_DIRECTORY}'")
+        os.makedirs(output_dir, exist_ok=True)
+        print(f"Output files will be saved to: '{output_dir}'")
 
         offline_data = load_offline_data()
         K = int(offline_data['K'])
@@ -188,8 +186,8 @@ def run_online_stage(re_input):
         coords_phys, p_out, u_out, v_out = to_physical_units(offline_data['coords'], p, u, v)
 
         # --- ✨ 5. 함수 호출 시 저장 경로를 전달 ---
-        save_solution_to_csv(coords_phys, p_out, u_out, v_out, Re, OUTPUT_DIRECTORY)
-        plot_solution_interpolated(coords_phys, p_out, u_out, v_out, Re, OUTPUT_DIRECTORY)
+        save_solution_to_csv(coords_phys, p_out, u_out, v_out, Re, output_dir)
+        plot_solution_interpolated(coords_phys, p_out, u_out, v_out, Re, output_dir)
         
         print(f"\n--- ONLINE STAGE COMPLETE for Re = {Re} ---")
 
@@ -201,6 +199,7 @@ def run_online_stage(re_input):
         print(f"An unexpected error occurred: {e}")
 
 if __name__ == '__main__':
+    default_output_dir = os.environ.get('ONLINE_OUTPUT_DIRECTORY', DEFAULT_OUTPUT_DIRECTORY)
     # 100부터 1000까지 25씩 증가하는 Reynolds 수 리스트 생성
     # np.arange(start, stop, step)은 stop 값을 포함하지 않으므로 1001로 설정
     re_list = np.arange(100, 1001, 25)
@@ -209,6 +208,6 @@ if __name__ == '__main__':
     print(re_list) # 생성된 리스트 확인 (선택 사항)
 
     for i in re_list:
-        run_online_stage(i)
+        run_online_stage(i, output_dir=default_output_dir)
 
     print("\nAll simulations finished.")


### PR DESCRIPTION
## Summary
- replace hard-coded offline data directory with a default relative to the script location and allow overriding via function argument or environment variable
- configure the online stage to derive its output directory relative to the script (or via parameter/environment) and reuse it across save/plot helpers
- extend the offline and online entry points to accept configurable paths while preserving existing behaviour

## Testing
- `python Galerkin_offline.py` *(fails: ModuleNotFoundError: No module named 'numpy'; dependencies unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6359692208323bf84a621bf7b8761