### PR TITLE
Refactor ROM assembly to use PDE abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ This repository provides a pipeline that builds a Proper Orthogonal Decompositio
 
 ## Key Components
 - `PreProcessing/preprocessing.py`: Sorts Fluent CSV snapshots by coordinates and generates `_sorted` files in batch.
-- `Galerkin_offline.py`: Extracts the interior grid from the sorted snapshots, computes POD modes, pre-computes Galerkin tensors, and stores them in `rom_offline_data.npz`.
+- `Galerkin_offline.py`: Extracts the interior grid from the sorted snapshots, computes POD modes, pre-computes Galerkin tensors, and stores them in `rom_offline_data.npz` along with metadata describing the PDE configuration.
 - `Galerkin_online.py`: Loads the offline data, solves the nonlinear equations for a specified Reynolds number, and exports the reconstructed pressure/velocity fields as CSV files and interpolated plots.
+- `rom/`: Lightweight abstraction layer that encapsulates the PDE-specific Galerkin projections. Additional PDEs can subclass the provided interfaces to reuse the offline pipeline.
 - `PostProcessing/CalculateL2.py`: Calculates the relative L2 error between the reference solution and ROM solution, and visualizes the error trend versus Reynolds number.
 
 ## Usage
 1. **Data sorting**  
    Place Fluent `case*.csv` files in a working folder such as `offlineDATA/` and run `python PreProcessing/preprocessing.py` to generate the `_sorted` files.
 2. **Offline stage**  
-   Run `python Galerkin_offline.py` to read `offlineDATA/case*_sorted.csv`, compute POD modes and Galerkin tensors, and store the results in `rom_offline_data.npz`.
+   Run `python Galerkin_offline.py` to read `offlineDATA/case*_sorted.csv`, compute POD modes and Galerkin tensors, and store the results in `rom_offline_data.npz`. The script also writes `rom_offline_metadata.json`, recording the PDE name, number of modes, and grid resolution used to assemble the reduced operators.
 3. **Online stage**  
    Run `python Galerkin_online.py`, enter the desired Reynolds number, and the reduced model will reconstruct the flow field, saving the output to `FinalResult/rom_solution_Re_<Re>.csv` along with PNG plots.
 4. **(Optional) Post-processing**  
@@ -25,5 +26,6 @@ This repository provides a pipeline that builds a Proper Orthogonal Decompositio
 
 ## Outputs
 - `rom_offline_data.npz`: POD modes, boundary conditions, and precomputed Galerkin coefficient tensors from the offline stage.
+- `rom_offline_metadata.json`: Supplementary metadata describing which PDE definition produced the stored tensors.
 - `FinalResult/rom_solution_Re_*.csv` and plots: Reconstructed pressure/velocity fields from the online stage.
 - `rom_error_vs_re.png`: Relative ROM error versus Reynolds number produced by the post-processing script.

--- a/rom/__init__.py
+++ b/rom/__init__.py
@@ -1,0 +1,17 @@
+"""Utility classes for configuring ROM equations."""
+
+from .pde import (
+    BoundaryData,
+    ModeDerivatives,
+    PDEContext,
+    PDEDefinition,
+    SteadyNavierStokesPDE,
+)
+
+__all__ = [
+    "BoundaryData",
+    "ModeDerivatives",
+    "PDEContext",
+    "PDEDefinition",
+    "SteadyNavierStokesPDE",
+]

--- a/rom/pde.py
+++ b/rom/pde.py
@@ -1,0 +1,149 @@
+"""Equation abstractions for Galerkin ROM construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+import numpy as np
+
+
+ArrayLike = np.ndarray
+
+
+@dataclass
+class ModeDerivatives:
+    """Container for POD modes and their spatial derivatives."""
+
+    phi_p: ArrayLike
+    phi_u: ArrayLike
+    phi_v: ArrayLike
+    dx_phi_p: ArrayLike
+    dy_phi_p: ArrayLike
+    dx_phi_u: ArrayLike
+    dy_phi_u: ArrayLike
+    dx_phi_v: ArrayLike
+    dy_phi_v: ArrayLike
+    lap_phi_u: ArrayLike
+    lap_phi_v: ArrayLike
+
+    @property
+    def num_modes(self) -> int:
+        return self.phi_u.shape[1]
+
+
+@dataclass
+class BoundaryData:
+    """Boundary condition data and derivatives."""
+
+    u_bc: ArrayLike
+    dx_u_bc: ArrayLike
+    dy_u_bc: ArrayLike
+    lap_u_bc: ArrayLike
+
+
+@dataclass
+class PDEContext:
+    """Aggregates data required to assemble reduced operators."""
+
+    modes: ModeDerivatives
+    boundary: BoundaryData
+    inner_product: Callable[[ArrayLike, ArrayLike], float]
+
+    def dot(self, lhs: ArrayLike, rhs: ArrayLike) -> float:
+        """Evaluate the configured inner product between two fields."""
+        return self.inner_product(lhs, rhs)
+
+
+class PDEDefinition:
+    """Interface for computing ROM tensors of a PDE."""
+
+    name: str = "abstract-pde"
+
+    def compute_constant_terms(self, ctx: PDEContext) -> Tuple[ArrayLike, ArrayLike]:
+        raise NotImplementedError
+
+    def compute_linear_terms(self, ctx: PDEContext) -> Tuple[ArrayLike, ArrayLike]:
+        raise NotImplementedError
+
+    def compute_quadratic_terms(self, ctx: PDEContext) -> ArrayLike:
+        raise NotImplementedError
+
+
+class SteadyNavierStokesPDE(PDEDefinition):
+    """Steady incompressible Navier–Stokes in primitive variables."""
+
+    name = "steady-incompressible-navier-stokes"
+
+    def compute_constant_terms(self, ctx: PDEContext) -> Tuple[ArrayLike, ArrayLike]:
+        K = ctx.modes.num_modes
+        C1 = np.zeros(K)
+        C2 = np.zeros(K)
+
+        for m in range(K):
+            phi_p_m = ctx.modes.phi_p[:, m]
+            phi_u_m = ctx.modes.phi_u[:, m]
+
+            C1[m] = ctx.dot(ctx.boundary.dx_u_bc, phi_p_m) + ctx.dot(
+                ctx.boundary.u_bc * ctx.boundary.dx_u_bc, phi_u_m
+            )
+            C2[m] = ctx.dot(-ctx.boundary.lap_u_bc, phi_u_m)
+
+        return C1, C2
+
+    def compute_linear_terms(self, ctx: PDEContext) -> Tuple[ArrayLike, ArrayLike]:
+        K = ctx.modes.num_modes
+        L1 = np.zeros((K, K))
+        L2 = np.zeros((K, K))
+
+        for m in range(K):
+            phi_p_m = ctx.modes.phi_p[:, m]
+            phi_u_m = ctx.modes.phi_u[:, m]
+            phi_v_m = ctx.modes.phi_v[:, m]
+
+            for j in range(K):
+                L1_rc = ctx.dot(
+                    ctx.modes.dx_phi_u[:, j] + ctx.modes.dy_phi_v[:, j],
+                    phi_p_m,
+                )
+                L1_ru = ctx.dot(
+                    ctx.boundary.u_bc * ctx.modes.dx_phi_u[:, j]
+                    + ctx.modes.phi_u[:, j] * ctx.boundary.dx_u_bc
+                    + ctx.modes.phi_v[:, j] * ctx.boundary.dy_u_bc
+                    + ctx.modes.dx_phi_p[:, j],
+                    phi_u_m,
+                )
+                L1_rv = ctx.dot(
+                    ctx.boundary.u_bc * ctx.modes.dx_phi_v[:, j]
+                    + ctx.modes.dy_phi_p[:, j],
+                    phi_v_m,
+                )
+                L1[m, j] = L1_rc + L1_ru + L1_rv
+
+                L2_ru = ctx.dot(-ctx.modes.lap_phi_u[:, j], phi_u_m)
+                L2_rv = ctx.dot(-ctx.modes.lap_phi_v[:, j], phi_v_m)
+                L2[m, j] = L2_ru + L2_rv
+
+        return L1, L2
+
+    def compute_quadratic_terms(self, ctx: PDEContext) -> ArrayLike:
+        K = ctx.modes.num_modes
+        Q = np.zeros((K, K, K))
+
+        for m in range(K):
+            phi_u_m = ctx.modes.phi_u[:, m]
+            phi_v_m = ctx.modes.phi_v[:, m]
+
+            for j in range(K):
+                dx_u_j = ctx.modes.dx_phi_u[:, j]
+                dy_u_j = ctx.modes.dy_phi_u[:, j]
+                dx_v_j = ctx.modes.dx_phi_v[:, j]
+                dy_v_j = ctx.modes.dy_phi_v[:, j]
+
+                for i in range(K):
+                    quad_u = ctx.modes.phi_u[:, i] * dx_u_j + ctx.modes.phi_v[:, i] * dy_u_j
+                    quad_v = ctx.modes.phi_u[:, i] * dx_v_j + ctx.modes.phi_v[:, i] * dy_v_j
+
+                    Q[m, i, j] = ctx.dot(quad_u, phi_u_m) + ctx.dot(quad_v, phi_v_m)
+
+        return Q


### PR DESCRIPTION
## Summary
- extract PDE-specific Galerkin assembly into a dedicated rom package with reusable context objects
- refactor the offline script to build tensors through the new Navier–Stokes definition and persist metadata about the setup
- surface the recorded metadata in the online solver and document the workflow updates in the README

## Testing
- python Galerkin_offline.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d63b6c4b508323adb8d5ca2dffeac5