### PR TITLE
Separate mean fields during POD processing

### DIFF
--- a/Galerkin_offline_pressureFullmode_normed.py
+++ b/Galerkin_offline_pressureFullmode_normed.py
@@ -249,14 +249,30 @@ def run_offline_stage(data_directory=None):
     # ---------------------------------
 
 
-    # 3. POD 수행
-    print(f"3. Performing POD for k={K} modes...")
-    U, s, Vh = svd(Q_interior, full_matrices=False)
+    # 3. 평균장 분리 및 POD 수행
+    print("3. Computing mean fields and performing POD on fluctuations...")
+    mean_interior = Q_interior.mean(axis=1)
+
+    p_mean_full = mean_interior[0:N_NODES]
+    u_mean_int = mean_interior[N_NODES:N_NODES + n_nodes_int]
+    v_mean_int = mean_interior[N_NODES + n_nodes_int:N_NODES + 2 * n_nodes_int]
+
+    def expand_interior_field(field_int):
+        """내부 격자에 정의된 필드를 전체 격자로 확장합니다."""
+        expanded = expand_modes(field_int.reshape(-1, 1), NX, NY)
+        return expanded[:, 0]
+
+    u_mean_full = expand_interior_field(u_mean_int)
+    v_mean_full = expand_interior_field(v_mean_int)
+
+    Q_fluct = Q_interior - mean_interior[:, None]
+
+    U, s, Vh = svd(Q_fluct, full_matrices=False)
     Phi_interior = U[:, :K]
 
 
     # 계수 통계량을 계산하여 온라인 단계에서 변수 스케일링에 활용
-    coeff_samples = Phi_interior.T @ Q_interior  # shape: (K, num_cases)
+    coeff_samples = Phi_interior.T @ Q_fluct  # shape: (K, num_cases)
     coeff_mean = coeff_samples.mean(axis=1)
     coeff_std = coeff_samples.std(axis=1)
     print("3b. Mean/Std of projected coefficients")
@@ -368,6 +384,7 @@ def run_offline_stage(data_directory=None):
     print("7. Saving offline data to 'rom_offline_data.npz'...")
     np.savez('rom_offline_data.npz',
              p_modes=p_modes_full, u_modes=u_modes, v_modes=v_modes,
+             p_mean=p_mean_full, u_mean=u_mean_full, v_mean=v_mean_full,
              u_bc=u_bc, coords=coords,
              C1=C1, C2=C2, L1=L1, L2=L2, Q=Q, K=K, NX=NX, NY=NY,
              alpha_mean=coeff_mean, alpha_std=coeff_std             

--- a/Galerkin_online_normed.py
+++ b/Galerkin_online_normed.py
@@ -86,9 +86,21 @@ def residual_with_monitor(alpha_scaled, Re, C1, C2, L1, L2, Q, alpha_mean, alpha
 def reconstruct_solution(alpha, modes_data):
     """계산된 계수 alpha를 사용하여 전체 유동장을 재구성합니다."""
     print("\nReconstructing full field solution...")
-    p = modes_data['p_modes'] @ alpha
-    u = modes_data['u_bc'] + (modes_data['u_modes'] @ alpha)
-    v = modes_data['v_modes'] @ alpha
+
+    p_mean = modes_data.get('p_mean')
+    u_mean = modes_data.get('u_mean')
+    v_mean = modes_data.get('v_mean')
+
+    if p_mean is None:
+        p_mean = np.zeros_like(modes_data['p_modes'][:, 0])
+    if u_mean is None:
+        u_mean = np.zeros_like(modes_data['u_modes'][:, 0])
+    if v_mean is None:
+        v_mean = np.zeros_like(modes_data['v_modes'][:, 0])
+
+    p = p_mean + (modes_data['p_modes'] @ alpha)
+    u = modes_data['u_bc'] + u_mean + (modes_data['u_modes'] @ alpha)
+    v = v_mean + (modes_data['v_modes'] @ alpha)
     return p, u, v
 
 # --- ✨ 2. 함수가 저장 경로를 인자로 받도록 수정 ---


### PR DESCRIPTION
## Summary
- subtract the mean pressure and velocity fields before POD and store the mean fields for later use
- save the mean fields alongside the ROM data for reuse during reconstruction
- update the online reconstruction to restore the saved mean fields in addition to the ROM modes

## Testing
- python -m compileall Galerkin_offline_pressureFullmode_normed.py Galerkin_online_normed.py

------
https://chatgpt.com/codex/tasks/task_e_68ec7466f8dc83238cdeaa6189835060